### PR TITLE
Added 2fa

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -14,7 +14,7 @@ from app.core.config import settings
 from app.db.base import Base
 
 # Import all models so Alembic can detect them
-from app.models.user import User, UserProfile  # noqa
+from app.models.user import User, UserProfile, OTPCode  # noqa
 from app.models.task import Course, Task  # noqa
 from app.models.schedule import FixedSlot  # noqa
 from app.models.sync import CalendarSyncState  # noqa

--- a/alembic/versions/f1a2b3c4d5e6_add_email_confirmed_and_otp_codes.py
+++ b/alembic/versions/f1a2b3c4d5e6_add_email_confirmed_and_otp_codes.py
@@ -1,0 +1,55 @@
+"""add_email_confirmed_and_otp_codes
+
+Revision ID: f1a2b3c4d5e6
+Revises: ea044ed96245
+Create Date: 2026-03-11 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'f1a2b3c4d5e6'
+down_revision: Union[str, None] = 'a87adc826289'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Add email_confirmed column to users table
+    op.add_column(
+        'users',
+        sa.Column('email_confirmed', sa.Boolean(), server_default='false', nullable=False),
+    )
+
+    # Create otp_codes table
+    op.create_table(
+        'otp_codes',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('email', sa.String(), nullable=False),
+        sa.Column('code', sa.String(6), nullable=False),
+        sa.Column('purpose', sa.String(), nullable=False, server_default='login'),
+        sa.Column('attempts', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('expires_at', sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(op.f('ix_otp_codes_id'), 'otp_codes', ['id'], unique=False)
+    op.create_index(op.f('ix_otp_codes_user_id'), 'otp_codes', ['user_id'], unique=False)
+    op.create_index(op.f('ix_otp_codes_email'), 'otp_codes', ['email'], unique=False)
+
+    # Mark all existing users as email_confirmed (they registered before this feature)
+    op.execute("UPDATE users SET email_confirmed = true")
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_otp_codes_email'), table_name='otp_codes')
+    op.drop_index(op.f('ix_otp_codes_user_id'), table_name='otp_codes')
+    op.drop_index(op.f('ix_otp_codes_id'), table_name='otp_codes')
+    op.drop_table('otp_codes')
+    op.drop_column('users', 'email_confirmed')

--- a/app/api/v1/auth.py
+++ b/app/api/v1/auth.py
@@ -1,32 +1,40 @@
 """
 Auth endpoints — merged from System A (login) + System B (Google OAuth).
-M1: POST /login/access-token
+M1: POST /login/access-token  — verify credentials, send OTP
+M1b: POST /login/verify-otp   — verify OTP, return JWT
+     POST /confirm-email       — confirm email address via token
+     POST /resend-confirmation  — resend confirmation email
 M3: GET  /google/authorize
 M4: GET  /google/callback
 """
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import RedirectResponse
 from fastapi.security import OAuth2PasswordRequestForm
-from sqlalchemy import or_, select
+from sqlalchemy import or_, select, delete
 from sqlalchemy.ext.asyncio import AsyncSession
 
 import secrets
 import urllib.parse
 
 from app.api import deps
-from app.core import security
+from app.core import security, utils
 from app.core.config import settings
-from app.models.user import User, UserProfile
+from app.models.user import User, UserProfile, OTPCode
 from app.models.sync import CalendarSyncState
 from app.services.google_oauth import GoogleOAuthService
 from app.services.calendar_service import CalendarService
 from app.services.sync_engine import SyncEngine
+from app.services.email_service import send_otp_email, send_email_confirmation
+from app.schemas.user import OTPVerify, EmailConfirmRequest
 
 router = APIRouter()
+
+MAX_OTP_ATTEMPTS = 5
+OTP_EXPIRY_MINUTES = 10
 
 # ── Shared service factories ─────────────────────────────────────────
 
@@ -43,14 +51,14 @@ def _sync_engine() -> SyncEngine:
     return SyncEngine(oauth, CalendarService(oauth))
 
 
-# ── M1 — Login ───────────────────────────────────────────────────────
+# ── M1 — Login (verify credentials → send OTP) ──────────────────────
 
 @router.post("/login/access-token")
 async def login_access_token(
     form_data: Annotated[OAuth2PasswordRequestForm, Depends()],
     db: Annotated[AsyncSession, Depends(deps.get_db)],
 ) -> Any:
-    """OAuth2 compatible token login, get an access token for future requests."""
+    """Verify credentials, then send a 6-digit OTP to the user's email."""
     result = await db.execute(
         select(User).where(
             or_(User.email == form_data.username, User.username == form_data.username)
@@ -61,11 +69,129 @@ async def login_access_token(
     if not user or not security.verify_password(form_data.password, user.password_hash):
         raise HTTPException(status_code=400, detail="Incorrect email or password")
 
+    if not user.email_confirmed:
+        raise HTTPException(
+            status_code=403,
+            detail="Email not confirmed. Please check your inbox for the confirmation link.",
+        )
+
+    # Clean up any existing OTP for this user
+    await db.execute(
+        delete(OTPCode).where(OTPCode.user_id == user.id, OTPCode.purpose == "login")
+    )
+
+    # Generate and store OTP
+    code = utils.generate_otp_code()
+    otp = OTPCode(
+        user_id=user.id,
+        email=user.email,
+        code=code,
+        purpose="login",
+        expires_at=datetime.utcnow() + timedelta(minutes=OTP_EXPIRY_MINUTES),
+    )
+    db.add(otp)
+    await db.commit()
+
+    # Send OTP email
+    send_otp_email(user.email, code)
+
+    return {"status": "otp_pending", "email": user.email}
+
+
+# ── M1b — Verify OTP ─────────────────────────────────────────────────
+
+@router.post("/login/verify-otp")
+async def verify_otp(
+    body: OTPVerify,
+    db: Annotated[AsyncSession, Depends(deps.get_db)],
+) -> Any:
+    """Verify the 6-digit OTP and return a JWT access token."""
+    result = await db.execute(
+        select(OTPCode).where(
+            OTPCode.email == body.email,
+            OTPCode.purpose == "login",
+        )
+    )
+    otp = result.scalars().first()
+
+    if not otp:
+        raise HTTPException(status_code=400, detail="No OTP found. Please log in again.")
+
+    if otp.expires_at < datetime.utcnow():
+        await db.delete(otp)
+        await db.commit()
+        raise HTTPException(status_code=400, detail="OTP expired. Please log in again.")
+
+    if otp.attempts >= MAX_OTP_ATTEMPTS:
+        await db.delete(otp)
+        await db.commit()
+        raise HTTPException(status_code=400, detail="Too many attempts. Please log in again.")
+
+    if otp.code != body.otp:
+        otp.attempts += 1
+        await db.commit()
+        remaining = MAX_OTP_ATTEMPTS - otp.attempts
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid OTP. {remaining} attempt(s) remaining.",
+        )
+
+    # OTP is valid — issue JWT
+    user_id = otp.user_id
+    await db.delete(otp)
+    await db.commit()
+
     access_token_expires = timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
     return {
-        "access_token": security.create_access_token(user.id, expires_delta=access_token_expires),
+        "access_token": security.create_access_token(user_id, expires_delta=access_token_expires),
         "token_type": "bearer",
     }
+
+
+# ── Email confirmation ────────────────────────────────────────────────
+
+@router.post("/confirm-email")
+async def confirm_email(
+    body: EmailConfirmRequest,
+    db: Annotated[AsyncSession, Depends(deps.get_db)],
+) -> Any:
+    """Confirm a user's email address using the token sent during registration."""
+    email = utils.verify_email_confirmation_token(body.token)
+    if not email:
+        raise HTTPException(status_code=400, detail="Invalid or expired confirmation link.")
+
+    result = await db.execute(select(User).where(User.email == email))
+    user = result.scalars().first()
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found.")
+
+    if user.email_confirmed:
+        return {"message": "Email already confirmed."}
+
+    user.email_confirmed = True
+    await db.commit()
+    return {"message": "Email confirmed successfully. You can now sign in."}
+
+
+@router.post("/resend-confirmation")
+async def resend_confirmation(
+    email: str = Query(...),
+    db: AsyncSession = Depends(deps.get_db),
+) -> Any:
+    """Resend the email confirmation link."""
+    result = await db.execute(select(User).where(User.email == email))
+    user = result.scalars().first()
+
+    if not user:
+        # Don't reveal whether the email exists
+        return {"message": "If that email is registered, a new confirmation link has been sent."}
+
+    if user.email_confirmed:
+        return {"message": "Email is already confirmed."}
+
+    token = utils.generate_email_confirmation_token(user.email)
+    send_email_confirmation(user.email, token)
+    return {"message": "If that email is registered, a new confirmation link has been sent."}
 
 
 # ── Google Sign-In (no JWT required) ────────────────────────────────
@@ -142,6 +268,7 @@ async def google_login_callback(
             username=username,
             # Google-authenticated users have no usable password
             password_hash=security.get_password_hash(secrets.token_urlsafe(32)),
+            email_confirmed=True,  # Google has already verified the email
         )
         db.add(user)
         await db.flush()  # populate user.id

--- a/app/api/v1/users.py
+++ b/app/api/v1/users.py
@@ -23,19 +23,20 @@ from app.schemas.user import (
     UserProfileBase,
     UserUpdatePassword,
 )
+from app.services.email_service import send_email_confirmation
 
 router = APIRouter()
 
 
 # ── M2 — Register ────────────────────────────────────────────────────
 
-@router.post("/", response_model=UserResponse)
+@router.post("/", status_code=201)
 async def create_user(
     *,
     db: Annotated[AsyncSession, Depends(deps.get_db)],
     user_in: UserCreate,
 ) -> Any:
-    """Create new user."""
+    """Create new user and send email confirmation."""
     result = await db.execute(select(User).where(User.email == user_in.email))
     if result.scalars().first():
         raise HTTPException(status_code=400, detail="The user with this email already exists in the system.")
@@ -48,6 +49,7 @@ async def create_user(
         email=user_in.email,
         username=user_in.username,
         password_hash=security.get_password_hash(user_in.password),
+        email_confirmed=False,
     )
     db.add(user)
     await db.commit()
@@ -59,7 +61,15 @@ async def create_user(
     await db.commit()
     await db.refresh(user, attribute_names=["profile"])
 
-    return user
+    # Send confirmation email
+    token = utils.generate_email_confirmation_token(user.email)
+    email_sent = send_email_confirmation(user.email, token)
+
+    return {
+        "message": "Account created. Please check your email to confirm your address.",
+        "email": user.email,
+        "email_sent": email_sent,
+    }
 
 
 # ── M5 — Get current user ────────────────────────────────────────────

--- a/app/core/utils.py
+++ b/app/core/utils.py
@@ -24,3 +24,33 @@ def verify_password_reset_token(token: str) -> Optional[str]:
     except jwt.JWTError as e:
         print(f"JWT Verification Error: {e}")
         return None
+
+
+def generate_email_confirmation_token(email: str) -> str:
+    delta = timedelta(hours=24)
+    now = datetime.now(timezone.utc)
+    expires = now + delta
+    exp = int(expires.timestamp())
+    encoded_jwt = jwt.encode(
+        {"exp": exp, "sub": email, "purpose": "email_confirmation"},
+        settings.SECRET_KEY,
+        algorithm="HS256",
+    )
+    return encoded_jwt
+
+
+def verify_email_confirmation_token(token: str) -> Optional[str]:
+    try:
+        decoded_token = jwt.decode(token, settings.SECRET_KEY, algorithms=["HS256"])
+        if decoded_token.get("purpose") != "email_confirmation":
+            return None
+        return decoded_token["sub"]
+    except jwt.JWTError as e:
+        print(f"Email confirmation JWT error: {e}")
+        return None
+
+
+def generate_otp_code() -> str:
+    """Generate a cryptographically secure 6-digit OTP code."""
+    import secrets
+    return f"{secrets.randbelow(900000) + 100000}"

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -8,7 +8,7 @@ Merged: google_refresh_token is nullable (not every user links Google).
 
 from datetime import datetime
 from typing import Optional, Any
-from sqlalchemy import String, Integer, DateTime, ForeignKey
+from sqlalchemy import String, Integer, Boolean, DateTime, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from sqlalchemy.dialects.postgresql import JSONB
 from app.db.base import Base
@@ -21,6 +21,7 @@ class User(Base):
     email: Mapped[str] = mapped_column(String, unique=True, index=True, nullable=False)
     username: Mapped[str] = mapped_column(String, unique=True, nullable=False)
     password_hash: Mapped[str] = mapped_column(String, nullable=False)
+    email_confirmed: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
     google_refresh_token: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
 
@@ -56,3 +57,19 @@ class UserProfile(Base):
     onboarding_data: Mapped[dict[str, Any]] = mapped_column(JSONB, default=dict)
 
     user: Mapped["User"] = relationship("User", back_populates="profile")
+
+
+class OTPCode(Base):
+    """Stores one-time passcodes for login verification and email confirmation."""
+    __tablename__ = "otp_codes"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    email: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    code: Mapped[str] = mapped_column(String(6), nullable=False)
+    purpose: Mapped[str] = mapped_column(String, nullable=False, default="login")  # "login" | "email_confirmation"
+    attempts: Mapped[int] = mapped_column(Integer, default=0)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -38,6 +38,7 @@ class UserProfileBase(BaseModel):
 
 class UserResponse(UserBase):
     id: int
+    email_confirmed: bool = False
     google_linked: bool = False
     profile: Optional[UserProfileBase] = None
 
@@ -50,11 +51,13 @@ class UserResponse(UserBase):
         if hasattr(data, "google_refresh_token"):
             # ORM object — read the token value safely
             token = getattr(data, "google_refresh_token", None)
+            confirmed = getattr(data, "email_confirmed", False)
             # Return a dict so Pydantic can set google_linked cleanly
             return {
                 "id": data.id,
                 "email": data.email,
                 "username": data.username,
+                "email_confirmed": confirmed,
                 "google_linked": token is not None and token != "",
                 "profile": data.profile,
             }
@@ -62,3 +65,16 @@ class UserResponse(UserBase):
             token = data.get("google_refresh_token")
             data["google_linked"] = token is not None and token != ""
         return data
+
+
+class OTPRequest(BaseModel):
+    email: EmailStr
+
+
+class OTPVerify(BaseModel):
+    email: EmailStr
+    otp: str
+
+
+class EmailConfirmRequest(BaseModel):
+    token: str

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -68,3 +68,107 @@ def send_password_reset_email(to_email: str, token: str) -> bool:
     except Exception as e:
         print(f"[EMAIL] Failed to send email to {to_email}: {e}")
         return False
+
+
+def _send_email(to_email: str, subject: str, html_body: str, text_body: str) -> bool:
+    """Generic SMTP send helper."""
+    if not settings.SMTP_USER or not settings.SMTP_PASSWORD:
+        print(f"[EMAIL] SMTP not configured for {to_email}")
+        return False
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = subject
+    msg["From"] = f"{settings.EMAILS_FROM_NAME} <{settings.SMTP_USER}>"
+    msg["To"] = to_email
+    msg.attach(MIMEText(text_body, "plain"))
+    msg.attach(MIMEText(html_body, "html"))
+
+    try:
+        with smtplib.SMTP(settings.SMTP_HOST, settings.SMTP_PORT) as server:
+            server.starttls()
+            server.login(settings.SMTP_USER, settings.SMTP_PASSWORD)
+            server.sendmail(settings.SMTP_USER, to_email, msg.as_string())
+        return True
+    except Exception as e:
+        print(f"[EMAIL] Failed to send email to {to_email}: {e}")
+        return False
+
+
+def send_otp_email(to_email: str, otp_code: str) -> bool:
+    """Send a 6-digit OTP code for login verification."""
+    subject = f"{settings.EMAILS_FROM_NAME} — Your sign-in code"
+    html_body = f"""
+    <html>
+    <body style="font-family: Arial, sans-serif; padding: 20px;">
+        <h2>Your Sign-In Code</h2>
+        <p>Hello,</p>
+        <p>Use the code below to complete your sign-in:</p>
+        <p style="margin: 30px 0; text-align: center;">
+            <span style="font-size: 36px; font-weight: bold; letter-spacing: 8px;
+                         background: #f4f4f4; padding: 16px 32px; border-radius: 8px;
+                         display: inline-block; color: #333;">
+                {otp_code}
+            </span>
+        </p>
+        <p style="color: #666;">This code expires in <strong>10 minutes</strong>.</p>
+        <hr style="margin: 30px 0; border: none; border-top: 1px solid #eee;">
+        <p style="color: #999; font-size: 12px;">
+            If you didn't try to sign in, you can safely ignore this email.
+        </p>
+    </body>
+    </html>
+    """
+    text_body = (
+        f"Your sign-in code: {otp_code}\n\n"
+        f"This code expires in 10 minutes.\n"
+        f"If you didn't request this, ignore this email."
+    )
+    sent = _send_email(to_email, subject, html_body, text_body)
+    if sent:
+        print(f"[EMAIL] OTP sent to {to_email}")
+    else:
+        print(f"[EMAIL] OTP for {to_email}: {otp_code}")
+    return sent
+
+
+def send_email_confirmation(to_email: str, token: str) -> bool:
+    """Send an email confirmation link to a newly registered user."""
+    frontend_url = getattr(settings, 'FRONTEND_URL', 'http://localhost:5173')
+    confirm_link = f"{frontend_url}/confirm-email?token={token}"
+
+    subject = f"{settings.EMAILS_FROM_NAME} — Confirm your email"
+    html_body = f"""
+    <html>
+    <body style="font-family: Arial, sans-serif; padding: 20px;">
+        <h2>Confirm Your Email Address</h2>
+        <p>Hello,</p>
+        <p>Thanks for signing up! Please confirm your email address by clicking the button below:</p>
+        <p style="margin: 30px 0;">
+            <a href="{confirm_link}"
+               style="background-color: #6366f1; color: white; padding: 12px 24px;
+                      text-decoration: none; border-radius: 4px; font-size: 16px;">
+                Confirm Email
+            </a>
+        </p>
+        <p>Or copy and paste this link into your browser:</p>
+        <p style="color: #666; word-break: break-all;">{confirm_link}</p>
+        <hr style="margin: 30px 0; border: none; border-top: 1px solid #eee;">
+        <p style="color: #999; font-size: 12px;">
+            If you didn't create an account, you can safely ignore this email.
+            This link expires in 24 hours.
+        </p>
+    </body>
+    </html>
+    """
+    text_body = (
+        f"Confirm your email\n\n"
+        f"Click this link to confirm your email:\n{confirm_link}\n\n"
+        f"This link expires in 24 hours.\n"
+        f"If you didn't sign up, ignore this email."
+    )
+    sent = _send_email(to_email, subject, html_body, text_body)
+    if sent:
+        print(f"[EMAIL] Confirmation email sent to {to_email}")
+    else:
+        print(f"[EMAIL] Confirmation link for {to_email}: {confirm_link}")
+    return sent


### PR DESCRIPTION
This pull request introduces email confirmation and one-time passcode (OTP) authentication to improve user account security and onboarding. The main changes include requiring users to confirm their email addresses after registration, sending OTP codes for login verification, and updating the database schema and models to support these features.

**Authentication and Email Confirmation Enhancements:**

* Added email confirmation flow after user registration, including endpoints to confirm email and resend confirmation links. Users must confirm their email before logging in.
* Implemented OTP-based login: after verifying credentials, a 6-digit OTP is sent to the user's email. The user must then verify the OTP to receive a JWT access token. 
**Database and Model Updates:**

* Added `email_confirmed` boolean field to the `User` model and database schema. Existing users are auto-confirmed in the migration. 

* Introduced a new `OTPCode` model and table to store OTPs for login and email confirmation, including fields for purpose, attempts, and expiry. (`app/models/user.py`, `alembic/versions/f1a2b3c4d5e6_add_email_confirmed_and_otp_codes.py`
**Utility and Schema Improvements:**

* Added utility functions for generating and verifying email confirmation tokens and OTP codes. (`app/core/utils.py`, [app/core/utils.pyR27-R56]

* Updated API schemas to include `email_confirmed` and new request/response models for OTP and email confirmation flows. (`app/schemas/user.py`,
**Email Service Enhancements:**

* Implemented generic email sending, OTP email, and email confirmation email functions

These changes collectively enforce email verification, add secure OTP-based login, and update the database and APIs to support these new authentication flows.